### PR TITLE
Add events to start/stop of dev_server

### DIFF
--- a/packages/repack/commands.js
+++ b/packages/repack/commands.js
@@ -102,6 +102,10 @@ module.exports = [
         name: '--log-file <string>',
         description: 'Enables file logging to specified file',
       },
+      {
+        name: '--send-events <string>',
+        description: 'Send packager events to a listener',
+      },
       webpackConfigOption
     ),
     description: startCommand.description,

--- a/packages/repack/src/commands/start.ts
+++ b/packages/repack/src/commands/start.ts
@@ -1,5 +1,6 @@
 import readline from 'readline';
 import { URL } from 'url';
+import path from 'path';
 import webpack from 'webpack';
 import execa from 'execa';
 import { Config } from '@react-native-community/cli-types';
@@ -33,7 +34,7 @@ export async function start(_: string[], config: Config, args: StartArguments) {
     config.root,
     args.webpackConfig
   );
-  const { reversePort: reversePortArg, ...restArgs } = args;
+  const { reversePort: reversePortArg, sendEvents: sendEventsArg, ...restArgs } = args;
   const cliOptions: CliOptions = {
     config: {
       root: config.root,
@@ -192,9 +193,17 @@ export async function start(_: string[], config: Config, args: StartArguments) {
 
   await start();
 
+  let sendEventsStop = () => {};
+  if (sendEventsArg) {
+    const sendEventsPath = path.join(config.root, sendEventsArg);
+    const { default: sendEvents } = await import(sendEventsPath);
+    sendEventsStop = await sendEvents(config.root);
+  }
+
   return {
     stop: async () => {
       reporter.stop();
+      sendEventsStop();
       await stop();
     },
   };

--- a/packages/repack/src/types.ts
+++ b/packages/repack/src/types.ts
@@ -79,6 +79,7 @@ export interface StartArguments extends CommonArguments {
   json?: boolean;
   reversePort?: boolean;
   logFile?: string;
+  sendEvents?: string;
 }
 
 /**


### PR DESCRIPTION
Adding an argument to `webpack-start` to be able to run code when the dev server starts/stops.